### PR TITLE
Add 'connector' tag to readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === AI Provider for Anthropic ===
 Contributors: wordpressdotorg
-Tags: ai, anthropic, claude, artificial-intelligence
+Tags: ai, anthropic, claude, artificial-intelligence, connector
 Requires at least: 6.9
 Tested up to: 7.0
 Stable tag: 1.0.1


### PR DESCRIPTION
Based on the recommendation in https://github.com/WordPress/gutenberg/pull/75833#issuecomment-3947453337 looking to add this tag so that this provider plugin (and others using the same tag) will populate into the linked WP Admin/WPORG plugin search results