### PR TITLE
feat: Thought signature support

### DIFF
--- a/src/Models/AnthropicTextGenerationModel.php
+++ b/src/Models/AnthropicTextGenerationModel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WordPress\AnthropicAiProvider\Models;
 
+use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Messages\DTO\Message;
@@ -244,10 +245,17 @@ class AnthropicTextGenerationModel extends AbstractApiBasedModel implements Text
         $type = $part->getType();
         if ($type->isText()) {
             if ($part->getChannel()->isThought()) {
-                return [
+                $data = [
                     'type' => 'thinking',
                     'thinking' => $part->getText(),
                 ];
+                if (version_compare(AiClient::VERSION, '1.3.0', '>=')) {
+                    $signature = $part->getThoughtSignature();
+                    if (null !== $signature) {
+                        $data['signature'] = $signature;
+                    }
+                }
+                return $data;
             }
             return [
                 'type' => 'text',
@@ -494,6 +502,8 @@ class AnthropicTextGenerationModel extends AbstractApiBasedModel implements Text
                 ($usage['cache_creation_input_tokens'] ?? 0) +
                 ($usage['cache_read_input_tokens'] ?? 0);
 
+            // Anthropic bundles thinking tokens into output_tokens and does not expose a separate count,
+            // so TokenUsage::thoughtTokens is left unset.
             $tokenUsage = new TokenUsage(
                 $inputTokens,
                 $usage['output_tokens'] ?? 0,
@@ -546,6 +556,16 @@ class AnthropicTextGenerationModel extends AbstractApiBasedModel implements Text
             case 'thinking':
                 if (!isset($partData['thinking']) || !is_string($partData['thinking'])) {
                     throw new InvalidArgumentException('Part has an invalid thinking shape.');
+                }
+                $signature = isset($partData['signature']) && is_string($partData['signature'])
+                    ? $partData['signature']
+                    : null;
+                if (null !== $signature && version_compare(AiClient::VERSION, '1.3.0', '>=')) {
+                    return new MessagePart(
+                        $partData['thinking'],
+                        MessagePartChannelEnum::thought(),
+                        $signature
+                    );
                 }
                 return new MessagePart($partData['thinking'], MessagePartChannelEnum::thought());
             case 'tool_use':

--- a/src/Models/AnthropicTextGenerationModel.php
+++ b/src/Models/AnthropicTextGenerationModel.php
@@ -249,7 +249,7 @@ class AnthropicTextGenerationModel extends AbstractApiBasedModel implements Text
                     'type' => 'thinking',
                     'thinking' => $part->getText(),
                 ];
-                if (version_compare(AiClient::VERSION, '1.3.0', '>=') && method_exists($part, 'getThoughtSignature')) {
+                if (method_exists($part, 'getThoughtSignature')) {
                     $signature = $part->getThoughtSignature();
                     if (null !== $signature) {
                         $data['signature'] = $signature;

--- a/src/Models/AnthropicTextGenerationModel.php
+++ b/src/Models/AnthropicTextGenerationModel.php
@@ -249,7 +249,7 @@ class AnthropicTextGenerationModel extends AbstractApiBasedModel implements Text
                     'type' => 'thinking',
                     'thinking' => $part->getText(),
                 ];
-                if (version_compare(AiClient::VERSION, '1.3.0', '>=')) {
+                if (version_compare(AiClient::VERSION, '1.3.0', '>=') && method_exists($part, 'getThoughtSignature')) {
                     $signature = $part->getThoughtSignature();
                     if (null !== $signature) {
                         $data['signature'] = $signature;
@@ -560,14 +560,11 @@ class AnthropicTextGenerationModel extends AbstractApiBasedModel implements Text
                 $signature = isset($partData['signature']) && is_string($partData['signature'])
                     ? $partData['signature']
                     : null;
+                $messagePartArgs = [$partData['thinking'], MessagePartChannelEnum::thought()];
                 if (null !== $signature && version_compare(AiClient::VERSION, '1.3.0', '>=')) {
-                    return new MessagePart(
-                        $partData['thinking'],
-                        MessagePartChannelEnum::thought(),
-                        $signature
-                    );
+                    $messagePartArgs[] = $signature;
                 }
-                return new MessagePart($partData['thinking'], MessagePartChannelEnum::thought());
+                return new MessagePart(...$messagePartArgs);
             case 'tool_use':
                 if (
                     !isset($partData['id']) ||


### PR DESCRIPTION
Closes #14 

## Summary

Round-trips `MessagePart::thoughtSignature` on the Anthropic adapter so multi-turn extended-thinking + tool-use exchanges work. Without it, Anthropic API rejects the request because the `signature` field is missing.

## Test plan

- [x] Inbound verified the `Title_Generation` Ability in Abilities Explorer, with vendor temporarily upgraded to `php-ai-client 1.3.1` and extended thinking. Captured a 384-char signature on the inbound `MessagePart`.
- [x] Outbound verified with a multi-turn CLI test: turn 1 produced a `thinking` + `tool_use` response; turn 2 echoed the assistant message back (with the captured signature) together with a `tool_result`. Anthropic accepted turn 2 and returned the final answer confirming the `signature` field is correctly serialised in the outbound JSON.