### PR TITLE
Release/1.0.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,5 @@ plugin.php export-ignore
 /.wordpress-org export-ignore
 /phpcs.xml.dist export-ignore
 /phpstan.neon.dist export-ignore
+
+/README.md export-ignore

--- a/plugin.php
+++ b/plugin.php
@@ -6,7 +6,7 @@
  * Description: AI Provider for Anthropic for the WordPress AI Client.
  * Requires at least: 6.9
  * Requires PHP: 7.4
- * Version: 1.0.2
+ * Version: 1.0.3
  * Author: WordPress AI Team
  * Author URI: https://make.wordpress.org/ai/
  * License: GPL-2.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Tags: ai, anthropic, claude, artificial-intelligence, connector
 Requires at least: 6.9
 Tested up to: 7.0
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 Requires PHP: 7.4
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -48,6 +48,10 @@ No, this plugin requires the PHP AI Client plugin to be installed and activated.
 
 == Changelog ==
 
+= 1.0.3 =
+
+* Add a provider logo to the metadata if the client version > 1.3.0 ([#18](https://github.com/WordPress/ai-provider-for-anthropic/pull/18)).
+
 = 1.0.2 =
 
 * Add plugin directory assets by @shaunandrews in https://github.com/WordPress/ai-provider-for-anthropic/pull/10


### PR DESCRIPTION
This pull request updates the plugin to version 1.0.3 and introduces a new feature that adds a provider logo to the metadata when the client version is greater than 1.3.0. It also updates documentation and packaging settings to reflect the new version.

Version update and new feature:

* Bumped the plugin version to 1.0.3 in `plugin.php` and `readme.txt` to mark the new release. [[1]](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96L9-R9) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6)
* Added a changelog entry describing the new feature: provider logo is included in the metadata if the client version is above 1.3.0.

Packaging and documentation:

* Updated `.gitattributes` to exclude `README.md` from export, ensuring it's not included in plugin distributions.