### PR TITLE
fix(anthropic): normalise empty-array args to empty object for tool_use.input

### DIFF
--- a/src/Models/AnthropicTextGenerationModel.php
+++ b/src/Models/AnthropicTextGenerationModel.php
@@ -325,9 +325,10 @@ class AnthropicTextGenerationModel extends AbstractApiBasedModel implements Text
                     'The function_call typed message part must contain a function call.'
                 );
             }
-            // Ensure null becomes empty object for Anthropic's API which expects an object.
+            // Ensure null or empty array becomes empty object for Anthropic's API which expects an object.
+            // PHP json_encode([]) produces "[]" (array), but Anthropic requires "{}" (object) for tool_use.input.
             $input = $functionCall->getArgs();
-            if ($input === null) {
+            if ($input === null || (is_array($input) && count($input) === 0)) {
                 $input = new \stdClass();
             }
             return [


### PR DESCRIPTION
## Problem

When an AI model invokes a tool/ability that takes no arguments, the generated `tool_use` block in the assistant message has `args` stored as an empty PHP array `[]`. When that history is later replayed back to Anthropic's API, PHP's `json_encode([])` serialises it as the JSON array `"[]"`, but Anthropic requires `tool_use.input` to be a JSON object (`"{}"`).

The result is a hard 400 from `https://api.anthropic.com/v1/messages`:

```
Bad Request (400)
messages.$i.content.$j.tool_use.input: Input should be an object
```

Reproducible by:

1. Defining (or using) an ability with no required parameters.
2. Letting the model call it once — the assistant turn is stored with `tool_use.input = []`.
3. Continuing the conversation so that the prior assistant turn is re-sent to Anthropic.
