### PR TITLE
fix: omit sampling parameters for models that reject them (Opus 4.7+)

### DIFF
--- a/src/Metadata/AnthropicModelMetadataDirectory.php
+++ b/src/Metadata/AnthropicModelMetadataDirectory.php
@@ -84,9 +84,6 @@ class AnthropicModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetad
         $anthropicOptions = [
             new SupportedOption(OptionEnum::systemInstruction()),
             new SupportedOption(OptionEnum::maxTokens()),
-            new SupportedOption(OptionEnum::temperature()),
-            new SupportedOption(OptionEnum::topP()),
-            new SupportedOption(OptionEnum::topK()),
             new SupportedOption(OptionEnum::stopSequences()),
             new SupportedOption(OptionEnum::outputMimeType(), ['text/plain', 'application/json']),
             new SupportedOption(OptionEnum::outputSchema()),
@@ -103,9 +100,11 @@ class AnthropicModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetad
             ),
             new SupportedOption(OptionEnum::outputModalities(), [[ModalityEnum::text()]]),
         ];
-        $anthropicWebSearchOptions = array_merge($anthropicOptions, [
-            new SupportedOption(OptionEnum::webSearch()),
-        ]);
+        $anthropicSamplingOptions = [
+            new SupportedOption(OptionEnum::temperature()),
+            new SupportedOption(OptionEnum::topP()),
+            new SupportedOption(OptionEnum::topK()),
+        ];
 
         $modelsData = (array) $responseData['data'];
 
@@ -114,15 +113,19 @@ class AnthropicModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetad
                 static function (array $modelData) use (
                     $anthropicCapabilities,
                     $anthropicOptions,
-                    $anthropicWebSearchOptions
+                    $anthropicSamplingOptions
                 ): ModelMetadata {
                     $modelId = $modelData['id'];
                     $modelCaps = $anthropicCapabilities;
+                    $modelOptions = $anthropicOptions;
+
+                    if (!self::modelRejectsSamplingParameters($modelId)) {
+                        $modelOptions = array_merge($modelOptions, $anthropicSamplingOptions);
+                    }
+
                     if (!preg_match('/^claude-3-[a-z]+/', $modelId)) {
                         // Only models newer than Claude 3 support web search.
-                        $modelOptions = $anthropicWebSearchOptions;
-                    } else {
-                        $modelOptions = $anthropicOptions;
+                        $modelOptions[] = new SupportedOption(OptionEnum::webSearch());
                     }
 
                     $modelName = $modelData['display_name'] ?? $modelId;
@@ -141,6 +144,49 @@ class AnthropicModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetad
         usort($models, [$this, 'modelSortCallback']);
 
         return $models;
+    }
+
+    /**
+     * Determines whether the given model rejects sampling parameters.
+     *
+     * Beginning with Claude Opus 4.7, the Anthropic API returns a 400 error when 'temperature', 'top_p', or 'top_k'
+     * are set to any non-default value. The same applies to the Claude 5 generation models (e.g. Claude Fable 5).
+     * Earlier Opus versions and the Sonnet and Haiku families (as of Sonnet 4.6 / Haiku 4.5) still accept sampling
+     * parameters.
+     *
+     * Unknown future models at major version 5 or higher are assumed to reject sampling parameters as well. If that
+     * assumption turns out wrong for a model, the model is merely not selected for prompts that require sampling
+     * parameters, whereas advertising support the model does not have would lead to hard API errors.
+     *
+     * @link https://platform.claude.com/docs/en/about-claude/models/migration-guide
+     *
+     * @since n.e.x.t
+     *
+     * @param string $modelId The model identifier, e.g. 'claude-opus-4-7'.
+     * @return bool True if the model rejects sampling parameters, false otherwise.
+     */
+    protected static function modelRejectsSamplingParameters(string $modelId): bool
+    {
+        /*
+         * Parse the Claude model family and major/minor version, e.g. 'claude-opus-4-7'.
+         * The minor version is limited to two digits so that a date suffix in model IDs
+         * without a minor version (e.g. 'claude-opus-4-20250514') is not mistaken for one.
+         */
+        if (!preg_match('/^claude-([a-z]+)-(\d+)(?:-(\d{1,2})(?!\d))?/', $modelId, $matches)) {
+            return false;
+        }
+
+        $family = $matches[1];
+        $major = (int) $matches[2];
+        $minor = isset($matches[3]) ? (int) $matches[3] : 0;
+
+        // All model families reject sampling parameters from major version 5 onwards.
+        if ($major >= 5) {
+            return true;
+        }
+
+        // Claude Opus 4.7 was the first model to reject sampling parameters.
+        return $family === 'opus' && $major === 4 && $minor >= 7;
     }
 
     /**


### PR DESCRIPTION
## What?

Stop advertising the sampling parameters (`temperature`, `top_p`, `top_k`) as supported options in the model metadata for Claude models that reject them, so the AI Client's model selection routes prompts that set a sampling parameter to models that actually honor it.

## Why?

Beginning with Claude Opus 4.7, the Anthropic API returns a `400` error when `temperature`, `top_p`, or `top_k` are set to any non-default value. The same applies to the Claude 5 generation models (e.g. Claude Fable 5 / Claude Mythos 5). See the [Claude model migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide):

> **Sampling parameters removed:** Setting `temperature`, `top_p`, or `top_k` to any non-default value on Claude Opus 4.7 returns a 400 error. The safest migration path is to omit these parameters entirely from request payloads.

Today the provider hardcodes `temperature`/`top_p`/`top_k` as supported options for **every** model. That breaks both ways the AI Client can be used:

- **Automatic model selection:** a prompt using `using_temperature( 0.7 )` can be routed to Claude Opus 4.7+ — the metadata claims support — and the request then fails with a `400`, even though models that honor the parameter (e.g. Claude Sonnet 4.6) were available.
- **Explicit model selection:** `using_model( $opus_4_8_model )->using_temperature( 0.7 )` fails with a `400`, but the SDK's `isSupported*()` checks could not have warned the developer beforehand, because the metadata says the option is supported.

## How?

The supported options are now built **per model** in `AnthropicModelMetadataDirectory::parseResponseToModelMetadataList()`, the same way the existing Claude 3 web-search distinction already works:

- A new `modelRejectsSamplingParameters( string $modelId ): bool` helper parses the Claude model family and major/minor version and returns `true` for **Claude Opus 4.7 and later**, and for **any model at major version 5 or higher** (Claude Fable 5, Claude Mythos 5, and future 5.x models of any family). Sonnet 4.6, Haiku 4.5, earlier Opus versions, and the Claude 3 family are unaffected.
- For matching models, the `temperature`, `top_p`, and `top_k` options are simply omitted from the advertised supported options. No request payloads are modified.

With truthful metadata, both usage paths behave correctly:

- **Automatic selection** routes sampling-parameter prompts to a model that supports them.
- **Explicit selection** of a rejecting model still sends the parameter and fails loudly with Anthropic's own descriptive `400` ("temperature is not supported for this model"), the `PHP Ai Client` SDK does not validate explicitly selected models against metadata, so existing explicit-model code is unaffected by this change.

Design notes:

- **Why over-match unknown 5.x models:** if a future 5.x model unexpectedly *does* accept sampling parameters, the cost is only that automatic selection routes around it; advertising support a model does not have would instead produce hard `400` errors. Anthropic's migration guide makes clear that removing sampling parameters is the direction of travel.
- **Version parsing:** the minor-version capture is limited to two digits so that dated model IDs without a minor version (e.g. `claude-opus-4-20250514`, i.e. Claude Opus 4.0) are not misparsed as having minor version `20250514`.
- **Companion SDK PR:** when a required option excludes every candidate model, the SDK previously reported it as a capability failure ("No models found that support text_generation for this prompt"), which would be misleading for consumers. WordPress/php-ai-client#254 makes that error name the unmet options instead, e.g. "Models supporting text_generation are available, but none of them support the following required options: temperature."

Scope note: this PR addresses the Opus 4.7+ / Claude 5 "sampling parameters rejected entirely" change. The separate Opus 4.1–4.6 / Sonnet 4.5 constraint (where `temperature` and `top_p` may not be set *together*, but either alone is fine) is intentionally left out of scope, as it requires a policy decision about which parameter to drop and cannot be expressed in the current supported-options metadata.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8, Claude Fable 5
Used for: Investigating the root cause across the provider, the PHP AI Client SDK, and the Anthropic migration guide; drafting the implementation. The final implementation was reviewed and edited by me.

## Testing Instructions

1. Configure the Anthropic provider with a valid API key.
2. Generate text with a non-default temperature **without** selecting a model explicitly:
   ```php
   wp_ai_client_prompt( 'Write a haiku about WordPress.' )
       ->using_temperature( 0.7 )
       ->generate_text_result();
   ```
   - **Before:** model selection may pick Claude Opus 4.7+ and the request fails with a `400`.
   - **After:** model selection picks a model that supports sampling parameters (e.g. Claude Sonnet 4.6) and the request succeeds with the temperature honored.
3. Inspect the model metadata (e.g. via the provider's model metadata directory) and confirm `temperature`/`top_p`/`top_k` are absent for Claude Opus 4.7+ and Claude 5 models, and still present for Claude Sonnet 4.6, Claude Haiku 4.5, and Claude Opus 4.6 and earlier.
4. Explicitly select a rejecting model with a sampling parameter and confirm the request fails with Anthropic's descriptive `400` (unchanged, intended behavior for invalid use):
   ```php
   wp_ai_client_prompt( 'Write a haiku about WordPress.' )
       ->using_temperature( 0.7 )
       ->using_model( $opus_4_8_model )
       ->generate_text_result();
   ```

## Changelog Entry

> Fixed - Stop advertising sampling parameters (`temperature`, `top_p`, `top_k`) as supported options for Claude models that reject them (Claude Opus 4.7+ and Claude 5 models), so model selection routes prompts using these options to models that honor them.
