### PR TITLE
feat: add anthropic-beta headers automatically when Skills container is used

### DIFF
--- a/src/Models/AnthropicTextGenerationModel.php
+++ b/src/Models/AnthropicTextGenerationModel.php
@@ -81,10 +81,21 @@ class AnthropicTextGenerationModel extends AbstractApiBasedModel implements Text
 
         $headers = ['Content-Type' => 'application/json'];
 
-        // Add beta header for structured outputs if JSON schema output is requested.
         $config = $this->getConfig();
+
+        // Add beta header for structured outputs if JSON schema output is requested.
         if ('application/json' === $config->getOutputMimeType() && $config->getOutputSchema()) {
             $headers['anthropic-beta'] = 'structured-outputs-2025-11-13';
+        }
+
+        // Add beta headers required for Skills (container parameter) if present in custom options.
+        $customOptions = $config->getCustomOptions();
+        if (!empty($customOptions['container']['skills'])) {
+            $skillsBetaHeaders = ['code-execution-2025-08-25', 'skills-2025-10-02'];
+            if (isset($headers['anthropic-beta'])) {
+                array_unshift($skillsBetaHeaders, $headers['anthropic-beta']);
+            }
+            $headers['anthropic-beta'] = implode(',', $skillsBetaHeaders);
         }
 
         $request = new Request(


### PR DESCRIPTION
## Problem

The Anthropic API requires two beta headers to use [Agent Skills](https://platform.claude.com/docs/en/build-with-claude/skills-guide) via the `container` parameter:

```
anthropic-beta: code-execution-2025-08-25,skills-2025-10-02
```

Currently, `generateTextResult()` only sets `anthropic-beta` in one case (structured outputs). There is no way for a caller to inject additional request headers, so Skills are inaccessible without editing the plugin.

### Skill Use-Case

End-users may have specific Skills they've created that incorporate editorial styles (e.g. AP Style), brand voice, or other guidance that they need in place to maximize utility of text review and generation.

## Solution

The `customOptions` mechanism in `ModelConfig` already allows callers to pass arbitrary body parameters (including `container`) without editing the plugin. This PR extends that pattern to headers: when `container.skills` is present in the custom options, the two required beta headers are appended automatically.

The implementation correctly composes with any existing `anthropic-beta` value (e.g. `structured-outputs-2025-11-13`).

## Usage

No plugin edits required — callers can now use Skills entirely via hooks:

```php
add_action( 'wp_ai_client_before_generate_result', function( $event ) {
    $config = $event->getModel()->getConfig();
    $existing = $config->getCustomOptions() ?? [];
    $config->setCustomOptions( array_merge( $existing, [
        'container' => [
            'skills' => [
                [ 'type' => 'anthropic', 'skill_id' => 'xlsx', 'version' => 'latest' ],
            ],
        ],
    ] ) );
} );
```

## Changes

- `src/Models/AnthropicTextGenerationModel.php`: moved `$config` assignment before the beta header block (minor cleanup), added Skills header detection after the existing structured-outputs check.