### PR TITLE
Bump WordPress tested-up-to version 7.1

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -1,17 +1,17 @@
 <?php
 
 /**
- * Plugin Name: AI Provider for Anthropic
- * Plugin URI: https://github.com/WordPress/ai-provider-for-anthropic
- * Description: AI Provider for Anthropic for the WordPress AI Client.
+ * Plugin Name:       AI Provider for Anthropic
+ * Plugin URI:        https://github.com/WordPress/ai-provider-for-anthropic
+ * Description:       AI Provider for Anthropic for the WordPress AI Client.
  * Requires at least: 6.9
- * Requires PHP: 7.4
- * Version: 1.0.3
- * Author: WordPress AI Team
- * Author URI: https://make.wordpress.org/ai/
- * License: GPL-2.0-or-later
- * License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
- * Text Domain: ai-provider-for-anthropic
+ * Requires PHP:      7.4
+ * Version:           1.0.3
+ * Author:            WordPress AI Team
+ * Author URI:        https://make.wordpress.org/ai/
+ * License:           GPL-2.0-or-later
+ * License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
+ * Text Domain:       ai-provider-for-anthropic
  *
  * @package WordPress\AnthropicAiProvider
  */

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,12 @@
 === AI Provider for Anthropic ===
-Contributors: wordpressdotorg
-Tags: ai, anthropic, claude, artificial-intelligence, connector
+Contributors:      wordpressdotorg
+Tags:              ai, anthropic, claude, artificial-intelligence, connector
 Requires at least: 6.9
-Tested up to: 7.0
-Stable tag: 1.0.3
-Requires PHP: 7.4
-License: GPL-2.0-or-later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Tested up to:      7.1
+Stable tag:        1.0.3
+Requires PHP:      7.4
+License:           GPL-2.0-or-later
+License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
 Anthropic (Claude) provider for the PHP AI Client SDK.
 


### PR DESCRIPTION
This pull request updates the compatibility information in the `readme.txt` file to indicate that the plugin has been tested up to WordPress version 7.1. as well as slight readability updates to that file and the `plugin.php` file to make heading spacing even.