### PR TITLE
Release/1.0.4

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -8,4 +8,5 @@
 /composer.lock
 /phpcs.xml.dist
 /phpstan.neon.dist
+/README.md
 /vendor

--- a/plugin.php
+++ b/plugin.php
@@ -6,7 +6,7 @@
  * Description:       AI Provider for Anthropic for the WordPress AI Client.
  * Requires at least: 6.9
  * Requires PHP:      7.4
- * Version:           1.0.3
+ * Version:           1.0.4
  * Author:            WordPress AI Team
  * Author URI:        https://make.wordpress.org/ai/
  * License:           GPL-2.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      wordpressdotorg
 Tags:              ai, anthropic, claude, artificial-intelligence, connector
 Requires at least: 6.9
 Tested up to:      7.1
-Stable tag:        1.0.3
+Stable tag:        1.0.4
 Requires PHP:      7.4
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -48,6 +48,17 @@ No, this plugin requires the PHP AI Client plugin to be installed and activated.
 
 == Changelog ==
 
+= 1.0.4 - 2026-08-17 =
+
+**Changed**
+
+* Bumped WordPress tested-up-to version 7.1 [#35](https://github.com/WordPress/ai-provider-for-anthropic/pull/35).
+
+**Fixed**
+
+* Corrected model metadata for Claude Opus 4.7 and later, including Claude 5 models, so unsupported sampling parameters are no longer advertised during automatic model selection [#25](https://github.com/WordPress/ai-provider-for-anthropic/pull/25).
+* Normalized empty tool-call arguments as JSON objects, preventing Anthropic API errors when replaying tool calls that accept no arguments [#23](https://github.com/WordPress/ai-provider-for-anthropic/pull/23).
+
 = 1.0.3 =
 
 * Add a provider logo to the metadata if the client version > 1.3.0 ([#18](https://github.com/WordPress/ai-provider-for-anthropic/pull/18)).

--- a/src/Metadata/AnthropicModelMetadataDirectory.php
+++ b/src/Metadata/AnthropicModelMetadataDirectory.php
@@ -160,7 +160,7 @@ class AnthropicModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetad
      *
      * @link https://platform.claude.com/docs/en/about-claude/models/migration-guide
      *
-     * @since n.e.x.t
+     * @since 1.0.4
      *
      * @param string $modelId The model identifier, e.g. 'claude-opus-4-7'.
      * @return bool True if the model rejects sampling parameters, false otherwise.


### PR DESCRIPTION
This pull request updates the plugin to version 1.0.4, bringing compatibility improvements, bug fixes for model metadata handling, and normalization of tool-call arguments to prevent Anthropic API errors. It also updates documentation and release metadata.

**Release and compatibility updates:**
* Bumped the plugin version to `1.0.4` in `plugin.php` and `readme.txt` to reflect the new release. [[1]](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96L9-R9) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6)
* Updated the "Tested up to" field for WordPress to version 7.1 in `readme.txt`.

**Bug fixes and improvements:**
* Corrected model metadata for Claude Opus 4.7+ and Claude 5 models so unsupported sampling parameters are no longer advertised during automatic model selection, preventing misconfiguration.
* Normalized empty tool-call arguments as JSON objects, preventing Anthropic API errors when replaying tool calls that accept no arguments.
* Updated the `@since` annotation in `AnthropicModelMetadataDirectory.php` to reflect the correct release version.

**Documentation and packaging:**
* Added `README.md` to `.distignore` to exclude it from distribution packages.