### PR TITLE
ci: add 5-minute timeout to WordPress.org deploy job

### DIFF
--- a/.github/workflows/deploy-to-wporg.yml
+++ b/.github/workflows/deploy-to-wporg.yml
@@ -8,6 +8,7 @@ jobs:
   deploy:
     name: Deploy to WordPress.org
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1


### PR DESCRIPTION
Normal deploys finish in under a minute; a broken apt mirror on a GitHub-hosted runner recently left the job hanging toward the default 6-hour timeout. Fail fast instead.