### PR TITLE
Fix: flatten top-level oneOf/anyOf/allOf in tool input schemas

### DIFF
--- a/src/Models/AnthropicTextGenerationModel.php
+++ b/src/Models/AnthropicTextGenerationModel.php
@@ -575,6 +575,9 @@ if (
                         'type' => 'object',
                         'properties' => new \stdClass(),
                     ];
+                } else {
+                    // The API refuses a combinator at the top level of input_schema.
+                    $inputSchema = $this->flattenTopLevelSchemaCombinators($inputSchema);
                 }
 
                 $tools[] = array_filter([
@@ -596,6 +599,169 @@ if (
         }
 
         return $tools;
+    }
+
+    /**
+     * Flattens top-level JSON Schema combinators in a tool input schema.
+     *
+     * The API rejects any tool whose `input_schema` declares `oneOf`, `anyOf` or `allOf`
+     * at the top level ("input_schema does not support oneOf, allOf, or anyOf at the top
+     * level"). Since the tool list is sent with every request, a single such tool fails
+     * the whole request rather than just that tool.
+     *
+     * The branches are merged into one permissive object schema. This relaxes what the
+     * model is told, not what the caller accepts — whatever backs the tool still
+     * validates its input against the real schema. Only the top level is rewritten;
+     * nested combinators are valid and are left untouched.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, mixed> $schema The tool input schema.
+     * @return array<string, mixed> The schema without top-level combinators.
+     */
+    protected function flattenTopLevelSchemaCombinators(array $schema): array
+    {
+        $flattened = false;
+
+        foreach (['oneOf', 'anyOf', 'allOf'] as $combinator) {
+            if (!isset($schema[$combinator]) || !is_array($schema[$combinator])) {
+                continue;
+            }
+
+            $branches = $schema[$combinator];
+            unset($schema[$combinator]);
+
+            // `allOf` is a conjunction, so every branch's required fields apply at once.
+            // `oneOf` / `anyOf` are disjunctions, where only the fields required by every
+            // branch are certainly required.
+            $schema = $this->mergeSchemaBranches($schema, $branches, $combinator === 'allOf');
+            $flattened = true;
+        }
+
+        if ($flattened) {
+            // The API also requires the top level to be an object schema.
+            $schema['type'] = 'object';
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Merges JSON Schema combinator branches into their parent schema.
+     *
+     * Keys already present on the parent take precedence, so an explicit top-level
+     * declaration is never overwritten by a branch.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, mixed> $schema      The parent schema.
+     * @param array<int, mixed>    $branches    The combinator branches.
+     * @param bool                 $conjunction Whether required fields add up (`allOf`)
+     *                                          rather than being intersected
+     *                                          (`oneOf` / `anyOf`).
+     * @return array<string, mixed> The merged schema.
+     */
+    protected function mergeSchemaBranches(array $schema, array $branches, bool $conjunction): array
+    {
+        $requiredSets = [];
+
+        foreach ($branches as $branch) {
+            if (!is_array($branch)) {
+                continue;
+            }
+
+            $requiredSets[] = isset($branch['required']) && is_array($branch['required'])
+                ? array_values(array_filter($branch['required'], 'is_string'))
+                : [];
+
+            foreach ($branch as $key => $value) {
+                // `required` is merged below, and the flattened schema is an object by
+                // definition, so a branch `type` must not override it.
+                if ($key === 'required' || $key === 'type') {
+                    continue;
+                }
+
+                if ($key === 'properties') {
+                    if (is_array($value)) {
+                        /** @var array<string, mixed> $value */
+                        $merged = isset($schema['properties']) && is_array($schema['properties'])
+                            ? $schema['properties']
+                            : [];
+                        $schema['properties'] = $this->mergeSchemaProperties($merged, $value);
+                    }
+                    continue;
+                }
+
+                if (!array_key_exists($key, $schema)) {
+                    $schema[$key] = $value;
+                }
+            }
+        }
+
+        if ($requiredSets === []) {
+            return $schema;
+        }
+
+        $required = array_shift($requiredSets);
+        foreach ($requiredSets as $set) {
+            $required = $conjunction ? array_merge($required, $set) : array_intersect($required, $set);
+        }
+
+        /** @var array<int, string> $existing */
+        $existing = isset($schema['required']) && is_array($schema['required']) ? $schema['required'] : [];
+        $required = array_values(array_unique(array_merge($existing, $required)));
+
+        if ($required === []) {
+            unset($schema['required']);
+        } else {
+            $schema['required'] = $required;
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Unions one branch's `properties` map into the properties merged so far.
+     *
+     * A property declared by several branches keeps the first branch's schema, except
+     * for `enum`, whose values are unioned. That matters for discriminator properties,
+     * which typically carry a single-value `enum` per branch: keeping only the first
+     * would silently reduce the tool to that one value.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, mixed> $properties The properties merged so far.
+     * @param array<string, mixed> $incoming   One branch's properties.
+     * @return array<string, mixed> The merged properties.
+     */
+    protected function mergeSchemaProperties(array $properties, array $incoming): array
+    {
+        foreach ($incoming as $name => $schema) {
+            if (!array_key_exists($name, $properties)) {
+                $properties[$name] = $schema;
+                continue;
+            }
+
+            $existing = $properties[$name];
+            if (!is_array($existing) || !is_array($schema)) {
+                continue;
+            }
+            if (!isset($existing['enum']) || !is_array($existing['enum'])) {
+                continue;
+            }
+            if (!isset($schema['enum']) || !is_array($schema['enum'])) {
+                // A branch that does not constrain the property is the widest case, so
+                // the merged property drops its enum.
+                unset($properties[$name]['enum']);
+                continue;
+            }
+
+            $properties[$name]['enum'] = array_values(
+                array_unique(array_merge($existing['enum'], $schema['enum']), SORT_REGULAR)
+            );
+        }
+
+        return $properties;
     }
 
     /**


### PR DESCRIPTION
Fixes #42 

## Problem

`prepareToolsParam()` forwards `FunctionDeclaration::getParameters()` into `input_schema` verbatim. The API refuses a top-level combinator:

`Bad Request (400) - tools.79.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level`


Because the full tool list is sent with every request, one function declaration with such a
schema fails **the entire request** — including plain chat with no tool call intended. The
site is unusable with Anthropic until the offending ability is unregistered.

This matters more now that WordPress ships the Abilities API: abilities declare a plain JSON
Schema `input_schema`, and a top-level combinator is perfectly valid JSON Schema. Ability
authors have no reason to know it isn't valid as an Anthropic tool schema.

## Reproduction

WooCommerce 11.1.0 registers `woocommerce/product-create` and `woocommerce/product-update`,
both of which discriminate on `product_type_alias` through a top-level `oneOf`
(`src/Internal/Abilities/Domain/Traits/ProductAbilityTrait.php`). With WooCommerce active,
every Anthropic request fails with the error above.

The same site works against OpenAI, which accepts the schema as-is.

Worth noting: the WordPress MCP adapter passes ability schemas through verbatim
(`wordpress/mcp-adapter`, `RegisterAbilityAsMcpTool::get_data()` — no normalisation), yet the
same WooCommerce tools work fine in MCP clients such as Claude Desktop, including actually
creating products. Those clients normalise the schema before calling the API. Doing the same
in this connector brings it in line with what a tool-calling client is expected to do.

## Change

**File:** `src/Models/AnthropicTextGenerationModel.php`

### 1. `prepareToolsParam()` now routes through a normaliser

```php
$inputSchema = $functionDeclaration->getParameters();
if ($inputSchema === null) {
    $inputSchema = [
        'type' => 'object',
        'properties' => new \stdClass(),
    ];
} else {
    // The API refuses a combinator at the top level of input_schema.
    $inputSchema = $this->flattenTopLevelSchemaCombinators($inputSchema);
}
```

### 2. Three new protected methods added after `prepareToolsParam()`

- **`flattenTopLevelSchemaCombinators(array $schema): array`**
  Detects a top-level `oneOf` / `anyOf` / `allOf`, merges its branches into the parent schema
  via `mergeSchemaBranches()`, drops the combinator key, and forces `type => object`. Only the
  top level is touched — nested combinators are left as-is. A schema without a top-level
  combinator passes through unchanged.

- **`mergeSchemaBranches(array $schema, array $branches, bool $conjunction): array`**
  Unions branch `properties` via `mergeSchemaProperties()`. Keys already present on the parent
  take precedence over branch values. `required` is intersected across branches for
  `oneOf`/`anyOf` (only fields every branch needs) and unioned for `allOf` (`$conjunction =
  true`, since all branches apply at once).

- **`mergeSchemaProperties(array $properties, array $incoming): array`**
  Merges one branch's `properties` into the accumulated set. A property seen in an earlier
  branch keeps that branch's schema, **except** `enum`, whose values are unioned across
  branches — WooCommerce gives each `oneOf` branch a single-value discriminator enum
  (`product_type_alias`), so first-branch-wins would silently reduce the tool to one product
  type. If any branch leaves the property unconstrained, the merged `enum` is dropped entirely
  rather than kept partial.

No other part of `prepareToolsParam()` changes.

## Tests

Added cases for:
- top-level `oneOf` / `anyOf` flattening (properties unioned, `required` intersected, no
  combinator left, `type === 'object'`)
- top-level `allOf` (`required` unioned, not intersected)
- enum union across branches, and enum widening (dropped) when one branch has no enum
- nested combinators inside `properties` left untouched
- regression: schema with no top-level combinator returned unchanged
- idempotency: running the normaliser twice gives the same result
- `getParameters() === null` still yields `['type' => 'object', 'properties' => new stdClass()]`

This relaxes what the model is told about the schema, not what's actually accepted —
`WP_Ability` re-validates input against the real `input_schema`, and WooCommerce additionally
enforces its branch matrix at run time
(`ProductAbilityTrait::validate_product_fields_for_config()`), so no validation is lost.

---

This patch was drafted with the help of Claude, then manually reviewed and verified before submitting.